### PR TITLE
[MRG] Make merchant_uid as fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-import random
-import string
+import uuid
 
 from pytest import fixture
 
@@ -28,5 +27,5 @@ def iamport(request):
 
 
 @fixture
-def merchant_uid(length=10):
-    return ''.join(random.choice(string.ascii_lowercase) for _ in range(length))
+def merchant_uid():
+    return str(uuid.uuid4())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import random
+import string
+
 from pytest import fixture
 
 from iamport import Iamport
@@ -22,3 +25,8 @@ def iamport(request):
     imp_key = request.config.getoption('--imp-key')
     imp_secret = request.config.getoption('--imp-secret')
     return Iamport(imp_key=imp_key, imp_secret=imp_secret)
+
+
+@fixture
+def merchant_uid(length=10):
+    return ''.join(random.choice(string.ascii_lowercase) for _ in range(length))

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -22,9 +22,9 @@ def test_partial_cancel(iamport):
         assert e.message == u'취소할 결제건이 존재하지 않습니다.'
 
 
-def test_cancel_by_merchant_uid(iamport):
+def test_cancel_by_merchant_uid(iamport, merchant_uid):
     payload = {
-        'merchant_uid': 'any-merchant_uid',
+        'merchant_uid': merchant_uid,
         'reason': 'any-reason',
     }
 
@@ -47,9 +47,9 @@ def test_cancel_without_merchant_uid(iamport):
         assert 'merchant_uid or imp_uid is required' in str(e)
 
 
-def test_cancel_by_merchant_uid_with_kwargs(iamport):
+def test_cancel_by_merchant_uid_with_kwargs(iamport, merchant_uid):
     payload = {
-        'merchant_uid': 'any-merchant_uid',
+        'merchant_uid': merchant_uid,
         'reason': 'any-reason',
         'amount': 1234,
     }

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -2,10 +2,10 @@
 import pytest
 
 
-def test_find(iamport):
+def test_find(iamport, merchant_uid):
     with pytest.raises(KeyError):
         iamport.find()
     with pytest.raises(iamport.HttpError):
         iamport.find(imp_uid='test')
     with pytest.raises(iamport.HttpError):
-        iamport.find(merchant_uid='âàáaā')
+        iamport.find(merchant_uid=merchant_uid)

--- a/tests/test_is_paid.py
+++ b/tests/test_is_paid.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
-def test_is_paid_with_response(iamport):
+def test_is_paid_with_response(iamport, merchant_uid):
     mocked_response = {
         'status': 'paid',
         'amount': 1000,
     }
-    assert True is iamport.is_paid(amount=1000, response=mocked_response, merchant_uid='test')
+    assert True is iamport.is_paid(amount=1000, response=mocked_response, merchant_uid=merchant_uid)
 
 
 def test_is_paid_without_response(iamport):
-    assert False is iamport.is_paid(amount=1000, merchant_uid='qwer1234')
+    assert False is iamport.is_paid(amount=1000, merchant_uid='qwer1234')  # 고정 필요

--- a/tests/test_pay_again.py
+++ b/tests/test_pay_again.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
 
-def test_pay_again(iamport):
+def test_pay_again(iamport, merchant_uid):
     # Without 'customer_uid'
     payload_notEnough = {
-        'merchant_uid': '1234qwer',
+        'merchant_uid': merchant_uid,
         'amount': 5000,
     }
 
@@ -15,7 +15,7 @@ def test_pay_again(iamport):
 
     payload_full = {
         'customer_uid': '00000000',
-        'merchant_uid': '1234qwer2',
+        'merchant_uid': merchant_uid,
         'amount': 5000,
     }
 

--- a/tests/test_pay_foreign.py
+++ b/tests/test_pay_foreign.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
-def test_pay_foreign(iamport):
+def test_pay_foreign(iamport, merchant_uid):
     payload = {
-        'merchant_uid': 'uid',
+        'merchant_uid': merchant_uid,
         'amount': 100,
         'card_number': 'card-number',
     }

--- a/tests/test_pay_onetime.py
+++ b/tests/test_pay_onetime.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
 
-def test_pay_onetime(iamport):
+def test_pay_onetime(iamport, merchant_uid):
     # Without 'card_number'
     payload_notEnough = {
-        'merchant_uid': 'qwer1234',
+        'merchant_uid': merchant_uid,
         'amount': 5000,
         'expiry': '2019-03',
         'birth': '500203',
@@ -17,7 +17,7 @@ def test_pay_onetime(iamport):
         assert "Essential parameter is missing!: card_number" in str(e)
 
     payload_full = {
-        'merchant_uid': 'qwer1234',
+        'merchant_uid': merchant_uid,
         'amount': 5000,
         'card_number': '4092-0230-1234-1234',
         'expiry': '2019-03',

--- a/tests/test_pay_schedule.py
+++ b/tests/test_pay_schedule.py
@@ -2,14 +2,14 @@
 import time
 
 
-def test_pay_schedule(iamport):
+def test_pay_schedule(iamport, merchant_uid):
     schedule_at = int(time.time() + 1000)
 
     payload_without_customer_uid = {
         # without 'customer_uid'
         'schedules': [
             {
-                'merchant_uid': 'pay_schedule_%s' % str(time.time()),
+                'merchant_uid': merchant_uid,
                 'schedule_at': schedule_at,
                 'amount': 2001,
                 'name': '주문명1',
@@ -53,7 +53,7 @@ def test_pay_schedule(iamport):
         'customer_uid': '00000000',
         'schedules': [
             {
-                'merchant_uid': 'pay_schedule_%s' % str(time.time()),
+                'merchant_uid': merchant_uid,
                 'schedule_at': schedule_at,
                 'amount': 5000,
                 'name': '주문명',

--- a/tests/test_pay_unschedule.py
+++ b/tests/test_pay_unschedule.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-import time
 
 
-def test_pay_unschedule(iamport):
+def test_pay_unschedule(iamport, merchant_uid):
     payload_without_customer_uid = {
         # without 'customer_uid'
-        'merchant_uid': 'pay_unschedule_%s' % str(time.time()),
+        'merchant_uid': merchant_uid,
     }
 
     try:
@@ -15,7 +14,7 @@ def test_pay_unschedule(iamport):
 
     payload_full = {
         'customer_uid': '00000000',
-        'merchant_uid': 'pay_unschedule_%s' % str(time.time()),
+        'merchant_uid': merchant_uid,
     }
 
     try:

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
-import datetime
-import time
 
-
-def test_prepare(iamport):
+def test_prepare(iamport, merchant_uid):
     amount = 12000
-    mid = 'merchant_%d' % time.mktime(datetime.datetime.now().timetuple())
 
-    result = iamport.prepare(merchant_uid=mid, amount=amount)
+    result = iamport.prepare(merchant_uid=merchant_uid, amount=amount)
     assert result['amount'] == amount
-    assert result['merchant_uid'] == mid
+    assert result['merchant_uid'] == merchant_uid
 
-    result = iamport.prepare_validate(merchant_uid=mid, amount=amount)
+    result = iamport.prepare_validate(merchant_uid=merchant_uid, amount=amount)
     assert result


### PR DESCRIPTION
기존 merchant_uid 가 각자의 규칙으로 만들어지고 있어, 중복되는 경우 테스트가 병렬적으로 돌아가지 않았던 문제가 있었습니다. 이 PR 에서는 merchant_uid 를 fixture 로 만들고, 각 테스트에서는 랜덤 문자열을 merchant_uid 로 사용합니다.